### PR TITLE
refactor | sprint3 | LC-114, LC-115, LC-109, LC-442, LC-111 | [JWT] JWT 구조 변경 > 파싱 및 요청헤더 생성 로직 수정 | SHUN

### DIFF
--- a/api-gateway/src/main/java/com/deefacto/api_gateway/filter/JwtAuthFilter.java
+++ b/api-gateway/src/main/java/com/deefacto/api_gateway/filter/JwtAuthFilter.java
@@ -79,7 +79,7 @@ public class JwtAuthFilter implements GlobalFilter, Ordered {
 
         // 인증이 필요하지 않은 경로들 (로그인, 회원가입)
         // 이 경로들은 JWT 토큰 없이도 접근 가능
-        if (path.startsWith("/auth/login") || path.startsWith("/auth/register")) {
+        if (path.startsWith("/auth/login")) {
             log.info("JwtAuthFilter - 인증 제외 경로: {}", path);
             // 인증 없이 바로 다음 필터/서비스로 요청 전달
             return chain.filter(exchange);
@@ -103,17 +103,13 @@ public class JwtAuthFilter implements GlobalFilter, Ordered {
         // JWT 토큰에서 사용자 정보 추출
         Long userId = jwtProvider.getUserIdFromToken(token);            // 유저 ID (불변)
         String employeeId = jwtProvider.getEmployeeIdFromToken(token);  // 직원 ID
-        String role = jwtProvider.getRoleFromToken(token);              // 사용자 역할
-        String shift = jwtProvider.getShiftFromToken(token);
         
-        log.info("JwtAuthFilter - 토큰 검증 성공: employeeId={}, role={}", employeeId, role);
+        log.info("JwtAuthFilter - 토큰 검증 성공: employeeId={}, userId={}", employeeId, userId);
 
         // 원본 요청에 사용자 정보를 헤더로 추가하여 새로운 요청 생성
         // 하위 서비스에서는 이 헤더를 통해 사용자 정보를 확인할 수 있음
         ServerHttpRequest modifiedRequest = exchange.getRequest().mutate()
                                             .header("X-Employee-Id", employeeId)  // 직원 ID 헤더
-                                            .header("X-Role", role)               // 역할 헤더
-                                            .header("X-Shift", shift)               // 근무시간 헤더
                                             .header("X-User-Id", String.valueOf(userId)) // 유저 ID 헤더
                                             .build();
 

--- a/api-gateway/src/main/java/com/deefacto/api_gateway/util/JwtProvider.java
+++ b/api-gateway/src/main/java/com/deefacto/api_gateway/util/JwtProvider.java
@@ -114,52 +114,6 @@ public class JwtProvider {
     }
 
     /**
-     * JWT 토큰에서 사용자 역할을 추출하는 메서드
-     * 
-     * 토큰의 페이로드에서 "role" claim을 추출하여 반환
-     * 
-     * @param token JWT 토큰 문자열
-     * @return 사용자 역할 문자열 (예: ADMIN, USER), 파싱 실패 시 null
-     */
-    public String getRoleFromToken(String token) {
-        try {
-            // JWT 토큰을 파싱하여 Claims 추출
-            Claims claims = Jwts.parser()
-                    .verifyWith(getSigningKey())  // 서명 키로 검증
-                    .build()
-                    .parseSignedClaims(token)     // 서명된 토큰 파싱
-                    .getPayload();                // 페이로드 추출
-                    
-            // Claims에서 "role" 키의 값을 String 타입으로 추출
-            return claims.get("Role", String.class);
-            
-        } catch (Exception e) {
-            // 토큰 파싱 중 오류 발생 시
-            log.error("JWT 토큰에서 사용자 역할 추출 중 오류 발생: {}", e.getMessage(), e);
-            return null;  // 추출 실패 시 null 반환
-        }
-    }
-
-    public String getShiftFromToken(String token) {
-        try {
-            // JWT 토큰을 파싱하여 Claims 추출
-            Claims claims = Jwts.parser()
-                    .verifyWith(getSigningKey())  // 서명 키로 검증
-                    .build()
-                    .parseSignedClaims(token)     // 서명된 토큰 파싱
-                    .getPayload();                // 페이로드 추출
-
-            // Claims에서 "employeeId" 키의 값을 String 타입으로 추출
-            return claims.get("Shift", String.class);
-
-        } catch (Exception e) {
-            // 토큰 파싱 중 오류 발생 시
-            log.error("JWT 토큰에서 유저 근무시간(shift) 추출 중 오류 발생: {}", e.getMessage(), e);
-            return null;  // 추출 실패 시 null 반환
-        }
-    }
-
-    /**
      * JWT 토큰 서명에 사용할 비밀키를 생성하는 메서드
      * 
      * 설정 파일(application.yml)에서 "jwt.secret-key" 값을 읽어와서


### PR DESCRIPTION
- userId, employeeId만 포함하도록 수정
- 인증 제외 경로에서 register 제외
  - 일반적인 서비스와 달리, root 계정만 회원 등록 가능하기에 인증 과정 필요